### PR TITLE
Use premultiplied alpha image and BlendMode::OVER

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "notan"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99e2c42dda1219f1676e45fd4ab26caa231b53877c16e3c6547e5b77d379184"
+checksum = "58ce09e2ce511e1415dc62d601c46281c2ea9cb13d23e5370d8a06aba9e7d4be"
 dependencies = [
  "notan_app",
  "notan_backend",
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "notan_app"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6ab033c6c8cd69a7dc43c9f8316ecc45f8eb5f32e8ccbaa65f93ccd7f44a3e"
+checksum = "19e942423487541a01252527457a72cc7476ca52fd9e174d02bd78e64e43ebae"
 dependencies = [
  "bytemuck",
  "downcast-rs",
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "notan_backend"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee80b80c22512d49ac6be86f24b97867f128b407c1f28bf13d0df91b314b09b"
+checksum = "e44ed3335faa35daa26e5ded583db96faf713a5c2798816bba82a5f2dbdba06c"
 dependencies = [
  "notan_web",
  "notan_winit",
@@ -1309,15 +1309,15 @@ dependencies = [
 
 [[package]]
 name = "notan_core"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233ac28c69499cd21418cb4727178d0b5ae447c56adcb902c9804b0f57597b56"
+checksum = "5f7950eada89cfd84044bf222edf1f37057860861aca7e181a55775a01393c79"
 
 [[package]]
 name = "notan_draw"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a7e70e853b576abe0a8daae412ceec556445221fd9791eaec261f8210f286f"
+checksum = "b51527743a6b408f97f005b73ca2f993ca847ddb1653974373704d8324ae0dc6"
 dependencies = [
  "log",
  "lyon",
@@ -1333,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "notan_glow"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8678356039e423ade74fb24b0acf778b359fa90c4f76de7606865cbf75749df8"
+checksum = "ba67cf062f771bd6cc2589b41295f9270d851e81b9d0b395d9cf2cce56a610d3"
 dependencies = [
  "bytemuck",
  "glow",
@@ -1350,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "notan_glyph"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd14161651a9f72e5d4dc7b1987261e14f028dc75c279b1886449a76aa032bf5"
+checksum = "b861a6ea6d388202fe79a495327b3e966608bef891330d0fb194195b94b0167a"
 dependencies = [
  "bytemuck",
  "glyph_brush",
@@ -1364,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "notan_graphics"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84fb56bb205e76dc98eeb0be2f4e020b745bf74ed96d49fbf6bdd52e487bb78"
+checksum = "bf2bfd7cc81ec2fb29b8539ae3b9fd9516aefd2dd6ee244c58951c93c21c126c"
 dependencies = [
  "bytemuck",
  "glsl-layout",
@@ -1379,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "notan_input"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073259fe8bfcd1370c28b4b11d9b62e8598e903b3af74019bc7274fab54339f5"
+checksum = "2b0d611dcb541d252cdc76d14acc09283ae2387db54ad95718cdcaf5085bd5fa"
 dependencies = [
  "hashbrown",
  "log",
@@ -1391,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "notan_log"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164ad6c6e42ea809c50e0647371a9f818674ce236c2725f8377e4b5b7dadfbd9"
+checksum = "ad0871a3fd9fed5580fcfe27f55259876ee2dd26db30760639f5bbd95faa782e"
 dependencies = [
  "console_log",
  "fern",
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "notan_macro"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf6151c731122be1b9a60e62a361273a1bf0751f310d8d6242dfd19eb39a056"
+checksum = "352cbcc8c9d2d0b69e54d9485b5e6efb3a7d51bd93e6abc35ea1102c2d2fd185"
 dependencies = [
  "glsl-to-spirv",
  "num",
@@ -1420,18 +1420,18 @@ dependencies = [
 
 [[package]]
 name = "notan_math"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42faa64ae7cceb52a4247671eaa5a5a7d1e15d72a1c94bc826b81ecf08788b0"
+checksum = "74828b12d9a440dfea7689acec7bc39520dd7054ea1cc229da16c6ebc55701d1"
 dependencies = [
  "glam",
 ]
 
 [[package]]
 name = "notan_random"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c77b1a2a0bfabe9ddbf8b1f1838415d13372f6321282f305bbc46a817801bb9"
+checksum = "a0632805dbd9e062c7a071e1513e6c1a05bfec5b1466c063ab80e3f4bff910f5"
 dependencies = [
  "getrandom",
  "rand",
@@ -1440,22 +1440,25 @@ dependencies = [
 
 [[package]]
 name = "notan_text"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adce2f1c80e9682e6bc53586db2f232a666a7b3fd16fd0f0c59297461ed323c"
+checksum = "f084de00054115d90737ad2f29fe66c1193490cf4298be2bd189d76e4d5b9d8b"
 dependencies = [
+ "hashbrown",
+ "lazy_static",
  "log",
  "notan_app",
  "notan_glyph",
  "notan_graphics",
  "notan_math",
+ "parking_lot",
 ]
 
 [[package]]
 name = "notan_utils"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4027aca2e974990d571aa0d54f5ff3e40cfb769b21046885bb36c1a58e900cab"
+checksum = "cd7f3451c32c4f2b8a95c7434f4cad13a474e355b06697398a41a6186417227b"
 dependencies = [
  "instant",
  "log",
@@ -1463,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "notan_web"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad164b50f071e419562a4fb3e7e65955546cc28821b0112510748f4b6a0238"
+checksum = "8216c69d28003406644409149f73d2b6fa5cb674f0a2d6a6cab5329ef6dd481e"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",
@@ -1482,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "notan_winit"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba15a805cdb2dea10b1591fc34912268011a32b4bd80869af2a06b6734aa9cc1"
+checksum = "f4d1de9a802471bbd69b429620afc43e7a809067cfc89cc825d8b0307a64013d"
 dependencies = [
  "glutin",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-notan = "0.7.1"
+notan = "0.8.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,11 @@ fn init(gfx: &mut Graphics) -> State {
 }
 
 fn texture(gfx: &mut Graphics, img: &[u8]) -> Texture {
-    gfx.create_texture().from_image(img).build().unwrap()
+    gfx.create_texture()
+        .from_image(img)
+        .with_premultiplied_alpha()
+        .build()
+        .unwrap()
 }
 
 fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
@@ -50,27 +54,23 @@ fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
     let width = W / 2.0;
     let scale = width / state.textures[0].width();
 
+    draw.set_blend_mode(Some(BlendMode::OVER));
+
     // Draw normal PNG
-    {
-        draw.image(&state.textures[0])
-            .translate(0.0, 0.0)
-            .scale(scale, scale);
-    }
+    draw.image(&state.textures[0])
+        .translate(0.0, 0.0)
+        .scale(scale, scale);
 
     // Draw transparent PNG
-    {
-        draw.image(&state.textures[1])
-            .translate(width, 0.0)
-            .scale(scale, scale);
-    }
+    draw.image(&state.textures[1])
+        .translate(width, 0.0)
+        .scale(scale, scale);
 
     // Draw transparent PNG with RenderTexture
     {
-        let mut d = gfx.create_draw();
-        d.set_size(TEX_W, TEX_H);
+        let mut d = state.rt1.create_draw();
         d.clear(Color::TRANSPARENT);
-        d.image(&state.textures[1])
-            .scale_from((TEX_W / 2.0, TEX_H / 2.0), (1.0, -1.0));
+        d.image(&state.textures[1]).blend_mode(BlendMode::OVER);
         gfx.render_to(&state.rt1, &d);
 
         draw.image(&state.rt1)
@@ -80,18 +80,9 @@ fn draw(app: &mut App, gfx: &mut Graphics, state: &mut State) {
 
     // Draw transparent PNG with RenderTexture twice
     {
-        let mut d1 = gfx.create_draw();
-        d1.set_size(TEX_W, TEX_H);
-        d1.clear(Color::TRANSPARENT);
-        d1.image(&state.textures[1])
-            .scale_from((TEX_W / 2.0, TEX_H / 2.0), (1.0, -1.0));
-        gfx.render_to(&state.rt1, &d1);
-
-        let mut d2 = gfx.create_draw();
-        d2.set_size(TEX_W, TEX_H);
+        let mut d2 = state.rt2.create_draw();
         d2.clear(Color::TRANSPARENT);
-        d2.image(&state.rt1)
-            .scale_from((TEX_W / 2.0, TEX_H / 2.0), (1.0, -1.0));
+        d2.image(&state.rt1).blend_mode(BlendMode::OVER);
         gfx.render_to(&state.rt2, &d2);
 
         draw.image(&state.rt2)


### PR DESCRIPTION
This PR fixes the transparency issue using `RenderTexture` using images with premultiplied alpha colors and changing the blend mode from `Normal -> (SrcAlpha, 1-SrcAlpha)` to `Over -> (1, 1-SrcAlpha)`.

<img width="797" alt="Screenshot 2022-11-28 at 22 45 09" src="https://user-images.githubusercontent.com/1929191/204403398-a466211e-6e3a-4876-b911-8553e9f8347a.png">

I am going to add some commentaries to the PR to give the changes some context. 

--- 

Thanks for this test case that you put together. The issue you found is related to premultiplied images and how the blend mode works with "premultiplied" and "non premultiplied" alpha images. The main issue seems that the OpenGL `framebuffers` (inner type of Notan's RenderTexture) use premultiplied alpha, so everything drawn to them with transparency needs to be also premultiplied. 

One way to do this without premultiplied alpha images is draw the image to the RenderTexture using `BlendMode::OVER` for the alpha, and then draw this RT to the screen with `Over` mode for the color blend mode:
```
    // Draw transparent PNG with RenderTexture
    {
        let mut d = state.rt1.create_draw();
        d.clear(Color::TRANSPARENT);
        d.image(&state.textures[1]).alpha_mode(BlendMode::OVER); // Alpha mode set as Over 
        gfx.render_to(&state.rt1, &d); 

        draw.image(&state.rt1)
            .blend_mode(BlendMode::OVER) // Now to screen as color blend mode Over
            .translate(0.0, H / 2.0)
            .scale(scale, scale);
    }
```

This works, but then, with the next case where you do `RT to RT to Screen` you need to do something slightly different, because the RT1 is using premultiplied alpha, so to draw to RT2 you don't need to use `alpha_mode : Over` anymore, but do as you do when drawing to the screen `(color_)blend_mode : Over`. 

```
    {
        let mut d2 = state.rt2.create_draw();
        d2.clear(Color::TRANSPARENT);
        d2.image(&state.rt1).blend_mode(BlendMode::OVER); // RT1 is premultiplied alpha so we need to use blend mode Over to draw to RT2
        gfx.render_to(&state.rt2, &d2);

        draw.image(&state.rt2)
            .translate(width, H / 2.0)
            .blend_mode(BlendMode::OVER) // RT2 is premultiplied alpha too, so we need the blend mode over.
            .scale(scale, scale);
    }
```  

This is a workaround using non-premultiplied alpha images when are drawn to a RT (which uses premultiplied alpha). 

But as you can see, this can be kind of confusing. So what this PR does, is process the textures to use premultiplied alpha, and then apply the Over blend mode for everything. This way you don't need to be careful with the blend modes or where are you drawing, everything behaves in the same way.

This makes me think that the `Draw2d` API should require premultiplied images always and use the `Over` blend mode by default. I need to think about it a little because this is going to be a breaking change. Some other libs as pixi.js already do this. So yeah, I am thinking that we should tell the user that they need to load premultiplied images or convert them when they are loaded (you can do that in notan with the `with_premutiplied_alpha()` option). But we can discuss this on notan's repo. 

